### PR TITLE
homo-deploy: Support LightGBM & Minor fix to work with KFServing v0.6.1

### DIFF
--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
@@ -48,6 +48,9 @@ def get_kfserving_deployer(party_model_id,
     elif framework_name in ['tf_keras', 'tensorflow', 'tf']:
         from .tensorflow import TFServingKFDeployer
         cls = TFServingKFDeployer
+    elif framework_name in ['lightgbm']:
+        from .lightgbm import LightGBMKFDeployer
+        cls = LightGBMKFDeployer
     else:
         raise ValueError("unknown converted model framework: {}".format(framework_name))
     return cls(party_model_id, model_version, model_object, service_id, **kwargs)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
@@ -15,11 +15,6 @@
 #
 
 
-from .pytorch import TorchServeKFDeployer
-from .sklearn import SKLearnV1KFDeployer, SKLearnV2KFDeployer
-from .tensorflow import TFServingKFDeployer
-
-
 def get_kfserving_deployer(party_model_id,
                            model_version,
                            model_object,
@@ -42,13 +37,16 @@ def get_kfserving_deployer(party_model_id,
     :return: an instance of the subclass of the base KFServingDeployer
     """
     if framework_name in ['sklearn', 'scikit-learn']:
+        from .sklearn import SKLearnV1KFDeployer, SKLearnV2KFDeployer
         if protocol_version == "v2":
             cls = SKLearnV2KFDeployer
         else:
             cls = SKLearnV1KFDeployer
     elif framework_name in ['pytorch', 'torch']:
+        from .pytorch import TorchServeKFDeployer
         cls = TorchServeKFDeployer
     elif framework_name in ['tf_keras', 'tensorflow', 'tf']:
+        from .tensorflow import TFServingKFDeployer
         cls = TFServingKFDeployer
     else:
         raise ValueError("unknown converted model framework: {}".format(framework_name))

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/lightgbm.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/lightgbm.py
@@ -1,0 +1,35 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+import os
+import tempfile
+from abc import ABC
+
+import kfserving
+
+from .base import KFServingDeployer
+
+
+class LightGBMKFDeployer(KFServingDeployer, ABC):
+    def _do_prepare_model(self):
+        working_dir = tempfile.mkdtemp()
+        local_file = os.path.join(working_dir, "model.bst")
+        self.model_object.save_model(local_file)
+        return local_file
+
+    def _do_prepare_predictor(self):
+        self.isvc.spec.predictor.lightgbm = kfserving.V1beta1LightGBMSpec(storage_uri=self.storage_uri)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/minio.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/minio.py
@@ -57,7 +57,9 @@ class MinIOModelStorage(BaseModelStorage):
         """
         super(MinIOModelStorage, self).__init__()
         self.bucket = bucket
-        self.sub_path = sub_path
+        # When parsing the uri, KFServing's storage initializer will incorrectly truncate it if
+        # it has pound key in it. Replace with another character.
+        self.sub_path = sub_path.replace("#", "^")
 
         if not endpoint:
             url = urlparse(os.getenv(ENV_MINIO_ENDPOINT_URL, "http://minio:9000"))

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/sklearn.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/sklearn.py
@@ -35,7 +35,10 @@ class SKLearnKFDeployer(KFServingDeployer, ABC):
 
 class SKLearnV1KFDeployer(SKLearnKFDeployer):
     def _do_prepare_predictor(self):
+        # Use our own sklearnserver image that has scikit-learn==0.24.2 because KFServing's default one
+        # uses scikit-learn==0.20.3 that cannot de-serialize models of higher versions.
         self.isvc.spec.predictor.sklearn = kfserving.V1beta1SKLearnSpec(
+            image="federatedai/sklearnserver:v0.6.1-0.24.2",
             protocol_version='v1',
             storage_uri=self.storage_uri)
 


### PR DESCRIPTION
1. In v0.6.1, KFServing's storage-initializer will incorrectly parse the s3 uri path if it has pound key in it. Since we are using model_id in the uri path, we need to change the pound key to other sign.

2. We have bumped our scikit-learn to a version (currently 0.24.2) higher that the KFServing's sklearnserver's default version (0.20.3) and it cannot consume our model. So we have to build our own sklearnserver image and explicitly use it.

3. Defer the import of deployers until they are being called.

4. Add a LightGBM deployer to deploy the converted SecureBoost Models.