### PR TITLE
Backward compatible with FATE-Serving versions before 2.1.0

### DIFF
--- a/python/fate_flow/db/db_services.py
+++ b/python/fate_flow/db/db_services.py
@@ -121,6 +121,14 @@ class ServicesDB(abc.ABC):
         except ServicesError as e:
             stat_logger.exception(e)
 
+    def register_flow(self):
+        """Call `self.insert` for insert the model transfer url to database.
+        Backward compatible with FATE-Serving versions before 2.1.0.
+
+        :return: None
+        """
+        self.insert('fateflow', get_model_download_endpoint())
+
     def register_model(self, party_model_id, model_version):
         """Call `self.insert` for insert a service url to database.
         Currently, only `fateflow` (model download) urls are supported.

--- a/python/fate_flow/fate_flow_server.py
+++ b/python/fate_flow/fate_flow_server.py
@@ -73,8 +73,11 @@ if __name__ == '__main__':
     RuntimeConfig.init_env()
     RuntimeConfig.init_config(JOB_SERVER_HOST=HOST, HTTP_PORT=HTTP_PORT)
     RuntimeConfig.set_process_role(ProcessRole.DRIVER)
+
     RuntimeConfig.set_service_db(service_db())
+    RuntimeConfig.SERVICE_DB.register_flow()
     RuntimeConfig.SERVICE_DB.register_models()
+
     ComponentRegistry.load()
     default_algorithm_provider = ProviderManager.register_default_providers()
     RuntimeConfig.set_component_provider(default_algorithm_provider)


### PR DESCRIPTION
This bug affects the versions before FATE-Serving 2.1.0 (including 2.0.5, 2.0.4, etc.). FATE-Serving may cannot find the pre-trained models if FATE 1.7.0 is used with FATE-Serving 2.0.5 (or older versions).

**We strongly suggest using FATE-Serving 2.1.1 or 2.1.0 with FATE-1.7.0.**

这个 bug 会影响 FATE-Serving 2.1.0 之前的版本（包括 2.0.5、2.0.4 等），当 FATE 1.7.0 与 FATE-Serving 2.0.5（或更早的版本）同时使用时，FATE-Serving 可能无法找到已经训练好的模型。

**推荐在使用 FATE 1.7.0 的时候，搭配使用 FATE-Serving 2.1.1 或 2.1.0。**