### PR TITLE
bugfix on 1.8.0 to data_manager

### DIFF
--- a/python/fate_flow/manager/data_manager.py
+++ b/python/fate_flow/manager/data_manager.py
@@ -285,7 +285,7 @@ def get_delete_filters(tracking_metric_model, metric_info):
     return delete_filters
 
 
-def get_component_output_data_schema(output_table_meta, extend_header, is_str=False):
+def get_component_output_data_schema(output_table_meta, extend_header, is_str=False) -> list:
     # get schema
     schema = output_table_meta.get_schema()
     if not schema:

--- a/python/fate_flow/manager/data_manager.py
+++ b/python/fate_flow/manager/data_manager.py
@@ -240,7 +240,6 @@ class TableStorage:
                 os.remove(path)
                 os.remove(output_data_meta_file_list[key])
             except Exception as e:
-                # warning
                 stat_logger.warning(e)
         return send_file(output_data_tarfile, attachment_filename=tar_file_name)
 
@@ -260,8 +259,8 @@ def delete_tables_by_table_infos(output_data_table_infos):
                         table.destroy()
                         data.append(table_info)
                         status = True
-                    except:
-                        pass
+                    except Exception as e:
+                        stat_logger.warning(e)
     return status, data
 
 
@@ -300,7 +299,7 @@ def get_component_output_data_schema(output_table_meta, extend_header, is_str=Fa
             if schema.get('sid'):
                 return [schema.get('sid')]
             else:
-                return None
+                return []
         header.extend([feature for feature in schema.get('header').split(',')])
     else:
         header.extend(schema.get('header', []))


### PR DESCRIPTION
@zhihuiwan 

修改文件：
python/fate_flow/manager/data_manager.py

修改内容：
1. 保持get_component_output_data_schema返回一致性，修改处原本返回None，在调用处存在空指针风险，改为空数组，保持方法返回一致，同时声明方法返回为list，如下对该访问的引用：
![image](https://user-images.githubusercontent.com/38832234/169974752-5f7cd8bd-09b7-4f54-b6a9-9fae5667c7a0.png)

2. delete_tables_by_table_infos函数捕获的异常增加日志打印
3. 去掉多余注释