### PR TITLE
bugfix on download.py --- type definition error

### DIFF
--- a/python/fate_flow/components/cache_loader.py
+++ b/python/fate_flow/components/cache_loader.py
@@ -21,7 +21,7 @@ from fate_flow.components._base import (
     ComponentInputProtocol,
 )
 from fate_flow.operation.job_tracker import Tracker
-from fate_flow.entity import MetricMeta
+from fate_flow.entity import MetricMeta, MetricType
 
 LOGGER = getLogger()
 
@@ -76,4 +76,4 @@ class CacheLoader(ComponentBase):
             metric_meta = cache.to_dict()
             metric_meta.pop("data")
             metric_meta["component_name"] = self.component_name
-            self.tracker.set_metric_meta(metric_namespace="cache_loader", metric_name=cache.name, metric_meta=MetricMeta(name="cache", metric_type="cache_info", extra_metas=metric_meta))
+            self.tracker.set_metric_meta(metric_namespace="cache_loader", metric_name=cache.name, metric_meta=MetricMeta(name="cache", metric_type=MetricType.CACHE_INFO, extra_metas=metric_meta))

--- a/python/fate_flow/components/download.py
+++ b/python/fate_flow/components/download.py
@@ -24,7 +24,7 @@ from fate_flow.components._base import (
     ComponentMeta,
     ComponentInputProtocol,
 )
-from fate_flow.entity import Metric, MetricMeta
+from fate_flow.entity import Metric, MetricMeta, MetricType
 from fate_flow.scheduling_apps.client import ControllerClient
 from fate_flow.utils import job_utils
 
@@ -118,5 +118,5 @@ class Download(ComponentBase):
         self.tracker.set_metric_meta(
             metric_namespace,
             metric_name,
-            MetricMeta(name="download", metric_type="DOWNLOAD"),
+            MetricMeta(name="download", metric_type=MetricType.DOWNLOAD),
         )

--- a/python/fate_flow/components/model_loader.py
+++ b/python/fate_flow/components/model_loader.py
@@ -16,7 +16,7 @@
 from fate_flow.utils.log_utils import getLogger
 
 from fate_flow.components._base import BaseParam, ComponentBase, ComponentInputProtocol, ComponentMeta
-from fate_flow.entity import JobConfiguration
+from fate_flow.entity import JobConfiguration, MetricType
 from fate_flow.entity import MetricMeta
 from fate_flow.model.checkpoint import CheckpointManager
 from fate_flow.pipelined_model.pipelined_model import PipelinedModel
@@ -74,7 +74,7 @@ class ModelLoader(ComponentBase):
 
         self.model_output = component_model
         self.tracker.set_metric_meta('model_loader', f'{self.component_name}-{self.model_alias}',
-                                     MetricMeta('component_model', 'component_model_info', {
+                                     MetricMeta('component_model', MetricType.COMPONENT_MODEL_INFO, {
                                          'model_id': self.model_id,
                                          'model_version': self.model_version,
                                          'component_name': self.component_name,
@@ -107,7 +107,7 @@ class ModelLoader(ComponentBase):
 
         self.model_output = data.pop('models')
         self.tracker.set_metric_meta('model_loader', f'{checkpoint.step_index}-{checkpoint.step_name}',
-                                     MetricMeta('checkpoint', 'checkpoint_info', data))
+                                     MetricMeta('checkpoint', MetricType.CHECKPOINT_INFO, data))
 
     def _run(self, cpn_input: ComponentInputProtocol):
         need_run = cpn_input.parameters.get('need_run', True)

--- a/python/fate_flow/components/upload.py
+++ b/python/fate_flow/components/upload.py
@@ -30,7 +30,7 @@ from fate_flow.components._base import (
     ComponentMeta,
     ComponentInputProtocol,
 )
-from fate_flow.entity import Metric, MetricMeta
+from fate_flow.entity import Metric, MetricMeta, MetricType
 from fate_flow.manager.data_manager import DataTableTracker
 from fate_flow.scheduling_apps.client import ControllerClient
 from fate_flow.db.job_default_config import JobDefaultConfig
@@ -448,7 +448,7 @@ class Upload(ComponentBase):
         self.tracker.set_metric_meta(
             metric_namespace="upload",
             metric_name="data_access",
-            metric_meta=MetricMeta(name="upload", metric_type="UPLOAD"),
+            metric_meta=MetricMeta(name="upload", metric_type=MetricType.UPLOAD),
         )
 
     def get_data_table_count(self, path, name, namespace):

--- a/python/fate_flow/entity/_metric.py
+++ b/python/fate_flow/entity/_metric.py
@@ -20,6 +20,7 @@ from fate_flow.entity import BaseEntity
 class MetricType(Enum):
     LOSS = 'LOSS'
     DOWNLOAD = 'DOWNLOAD'
+    CACHE_INFO = 'cache_info'
 
 
 class Metric(BaseEntity):

--- a/python/fate_flow/entity/_metric.py
+++ b/python/fate_flow/entity/_metric.py
@@ -19,6 +19,7 @@ from fate_flow.entity import BaseEntity
 
 class MetricType(Enum):
     LOSS = 'LOSS'
+    DOWNLOAD = 'DOWNLOAD'
 
 
 class Metric(BaseEntity):

--- a/python/fate_flow/entity/_metric.py
+++ b/python/fate_flow/entity/_metric.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import typing
 from enum import Enum
 from fate_flow.entity import BaseEntity
 
@@ -21,6 +22,9 @@ class MetricType(Enum):
     LOSS = 'LOSS'
     DOWNLOAD = 'DOWNLOAD'
     CACHE_INFO = 'cache_info'
+    CHECKPOINT_INFO = 'checkpoint_info'
+    UPLOAD = 'UPLOAD'
+    COMPONENT_MODEL_INFO = 'component_model_info'
 
 
 class Metric(BaseEntity):
@@ -35,7 +39,7 @@ class Metric(BaseEntity):
 
 
 class MetricMeta(BaseEntity):
-    def __init__(self, name: str, metric_type: MetricType, extra_metas: dict = None):
+    def __init__(self, name: str, metric_type: typing.Union[MetricType, str], extra_metas: dict = None):
         self.name = name
         self.metric_type = metric_type
         self.metas = {}


### PR DESCRIPTION
@jat001 @dylan-fan @zhihuiwan 

修改文件：
1. python/fate_flow/components/download.py
2. python/fate_flow/entity/_metric.py
3. python/fate_flow/components/cache_loader.py
4. python/fate_flow/components/model_loader.py
5. python/fate_flow/components/upload.py

修改内容：
1. MetricMeta类__init__函数签名定义为枚举类型MetricType，callback_metric方法、CacheLoader的_run方法均传入str类型
2. 部分代码调用MetricMeta类，传入的metric_type参数为从上层参数种解析获取到，无法定义为枚举，只能传入str，故将MetricMeta初始化函数中metric_type参数定义为typing.Union[MetricType, str]类型，支持MetricType枚举及字符串两种类型