### PR TITLE
bugfix

### DIFF
--- a/python/fate_flow/operation/job_clean.py
+++ b/python/fate_flow/operation/job_clean.py
@@ -45,7 +45,7 @@ class JobClean(object):
                     stat_logger.info('stop {} {} {} {} session success'.format(task.f_job_id, task.f_role,
                                                                                task.f_party_id, task.f_component_name))
                 except Exception as e:
-                    pass
+                    stat_logger.info(f'start_session_stop occur exception: {e}')
                 try:
                     # clean data table
                     JobClean.clean_table(job_id=task.f_job_id, role=task.f_role, party_id=task.f_party_id,

--- a/python/fate_flow/utils/job_utils.py
+++ b/python/fate_flow/utils/job_utils.py
@@ -43,9 +43,9 @@ class JobIdGenerator(object):
         self._max = 99999
 
     def next_id(self):
-        '''
+        """
         generate next job id with locking
-        '''
+        """
         #todo: there is duplication in the case of multiple instances deployment
         now = datetime.datetime.now()
         with JobIdGenerator._lock:


### PR DESCRIPTION
@zhihuiwan 

修改文件：
python/fate_flow/operation/job_clean.py
python/fate_flow/utils/job_utils.py

修改内容：
1. clean_job中对于捕获的异常进行日志打印、避免异常被直接吞掉毫不知情
2. docstring采用标准双引号格式，__doc__函数才会生效、单引号格式docstring标准不推荐、且__doc__不生效