### PR TITLE
add the K8s infra code

### DIFF
--- a/python/fate_flow/flow/manager.py
+++ b/python/fate_flow/flow/manager.py
@@ -1,6 +1,11 @@
-import json
+from os import path
 
+import traceback
+import yaml
+import json
 import docker
+
+from kubernetes import client, config, stream
 
 
 class BaseManager:
@@ -85,3 +90,130 @@ class DockerManager(BaseManager):
 
     def check_task(self, *args, **kwargs):
         pass
+
+
+class K8sManager(BaseManager):
+
+    # This manager is for managing the algorithm container under k8s env,
+    # especially when FATE is deployed by KubeFATE.
+
+    def __init__(self, image):
+        self.core_api = client.CoreV1Api()
+        self.app_api = client.AppsV1Api()
+        self.namespace = K8sUtils.get_namespace()
+        self._load_yaml_file("yaml-files/algorithm.yaml", image)
+        self.sts_name = self.sts_conf.get("metadata", {}).get("name")
+        self.pod_name = "%s-0" % self.sts_name
+        if not self.sts_name:
+            print("failed to read the sts name from the sts yaml file")
+
+    def _load_yaml_file(self, file_path: str, image: str):
+        with open(path.join(path.dirname(__file__), file_path)) as f:
+            self.sts_conf = yaml.safe_load(f)
+        self.sts_conf['spec']['template']['spec']['containers'][0]['image'] = image
+
+    def create_sts(self) -> bool:
+        try:
+            resp = self.app_api.create_namespaced_stateful_set(
+                namespace=self.namespace, body=self.sts_conf)
+            return True
+        except:
+            traceback.print_exc()
+            return False
+
+    def is_sts_exist(self) -> bool:
+        sts_list = [sts.metadata.name for sts in
+                    self.app_api.list_namespaced_stateful_set(self.namespace).items]
+        return True if self.sts_name in sts_list else False
+
+    def describe_sts(self) -> client.V1StatefulSet:
+        resp = self.app_api.read_namespaced_stateful_set_status(
+            namespace=self.namespace, name=self.sts_name)
+        return resp
+
+    def is_pod_ready(self) -> bool:
+        if not self.is_sts_exist():
+            return False
+        return self.describe_sts().status.ready_replicas > 0
+
+    def destroy_sts(self) -> bool:
+        try:
+            resp = self.app_api.delete_namespaced_stateful_set(
+                name=self.sts_name,
+                namespace=self.namespace,
+            )
+            if resp.status.lower() == K8sUtils.SUCCESS:
+                return True
+            return False
+        except:
+            traceback.print_exc()
+            return False
+
+    def exec_run(self, commands: list) -> str:
+        # Calling exec and waiting for response
+        try:
+            output = stream.stream(
+                self.core_api.connect_get_namespaced_pod_exec,
+                name=self.pod_name,
+                namespace=self.namespace,
+                command=commands,
+                stderr=True, stdin=False,
+                stdout=True, tty=False)
+            print("Response: " + output)
+        except:
+            traceback.print_exc()
+            output = None
+        return output
+
+    def run_task(self, cmd, name):
+        return self.exec_run(cmd, name)
+
+    def stop_task(self, cmd, name):
+        return self.exec_run(cmd, name)
+
+    def component_status(self):
+        return self.is_pod_ready()
+
+    def component_registry(self, image, name):
+        pass
+
+    def component_revoke(self, *args, **kwargs):
+        pass
+
+    def check_task(self, *args, **kwargs):
+        pass
+
+
+class K8sUtils:
+    SUCCESS = "success"
+
+    @classmethod
+    def load_in_cluster_config(cls) -> None:
+        config.load_incluster_config()
+
+    @classmethod
+    def get_namespace(cls) -> str:
+        # In below file, the pod can read it is in which K8s namespace
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
+            namespace = f.readline()
+        return namespace
+
+
+'''
+# Usage:
+if __name__ == '__main__':
+    K8sUtils.load_in_cluster_config()
+    # Control using which algorithm here
+    k8s_manager = K8sManager(image="federatedai/algorithm:v2.0")
+    k8s_manager.create_sts()
+    exec_command = [
+        '/bin/sh',
+        '-c',
+        'mkdir /data/projects/fate/fateflow/logs/hello'
+    ]
+    k8s_manager.exec_run(exec_command)
+    res = k8s_manager.is_sts_exist()
+    res = k8s_manager.is_pod_ready()
+    k8s_manager.destroy_sts()
+'''
+

--- a/python/fate_flow/flow/yaml_files/algorithm.yaml
+++ b/python/fate_flow/flow/yaml_files/algorithm.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: algorithm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      module: algorithm
+  serviceName: algorithm
+  template:
+    metadata:
+      labels:
+        module: algorithm
+    spec:
+      containers:
+        - name: algorithm
+          image:
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: algorithm-data
+              mountPath: /data/projects/fate/fateflow/logs
+              subPath: logs
+            - name: algorithm-data
+              mountPath: /data/projects/fate/fateflow/jobs
+              subPath: jobs
+      serviceAccountName: default
+      restartPolicy: Always
+      volumes:
+        - name: algorithm-data
+          emptyDir: {}


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

## Description

When deploying FATE by KubeFATE, we will give a service account for the fateflow pod.
https://github.com/FederatedAI/KubeFATE/pull/795

Now I have verified that Fateflow has the authority to
1. do CRUD to a statefulset.
2. can execute command in the algorithm pod/container.
3. can read log of the pod.
4. change the image name to switch between fate algorithm container and algorithm container provided by other companie.

The next steps are:
1. design the docker file of the algorithm image of fate.
2. call the api I provide in the main stream code.