### PR TITLE
Fix hdfs address in dependence_upload worker

### DIFF
--- a/python/fate_flow/worker/dependence_upload.py
+++ b/python/fate_flow/worker/dependence_upload.py
@@ -103,7 +103,7 @@ class DependenceUpload(BaseWorker):
 
         LOGGER.info(f'start upload')
         snapshot_time = DependenceRegistry.get_modify_time(source_path)
-        storage_dir = f"{ServerRegistry.HDFS.NAME_NODE}/fate_dependence/{provider.version}"
+        storage_dir = f"{ServerRegistry.HDFS.get('name_node')}/fate_dependence/{provider.version}"
         os.system(f" {os.getenv('HADOOP_HOME')}/bin/hdfs dfs -mkdir -p  {storage_dir}")
         status = os.system(f"{os.getenv('HADOOP_HOME')}/bin/hdfs dfs -put -f {target_file} {storage_dir}")
         LOGGER.info(f'upload end, status is {status}')

--- a/python/fate_flow/worker/dependence_upload.py
+++ b/python/fate_flow/worker/dependence_upload.py
@@ -22,6 +22,7 @@ from fate_arch.common import file_utils
 from fate_flow.utils.log_utils import getLogger
 from fate_flow.db.db_models import ComponentProviderInfo
 from fate_flow.db.dependence_registry import DependenceRegistry
+from fate_flow.db.service_registry import ServerRegistry
 from fate_flow.entity import ComponentProvider
 from fate_flow.entity.types import FateDependenceName, ComponentProviderName, FateDependenceStorageEngine
 from fate_flow.settings import FATE_VERSION_DEPENDENCIES_PATH
@@ -102,7 +103,7 @@ class DependenceUpload(BaseWorker):
 
         LOGGER.info(f'start upload')
         snapshot_time = DependenceRegistry.get_modify_time(source_path)
-        storage_dir = f"/fate_dependence/{provider.version}"
+        storage_dir = f"{ServerRegistry.HDFS.NAME_NODE}/fate_dependence/{provider.version}"
         os.system(f" {os.getenv('HADOOP_HOME')}/bin/hdfs dfs -mkdir -p  {storage_dir}")
         status = os.system(f"{os.getenv('HADOOP_HOME')}/bin/hdfs dfs -put -f {target_file} {storage_dir}")
         LOGGER.info(f'upload end, status is {status}')

--- a/python/fate_flow/worker/dependence_upload.py
+++ b/python/fate_flow/worker/dependence_upload.py
@@ -103,9 +103,11 @@ class DependenceUpload(BaseWorker):
 
         LOGGER.info(f'start upload')
         snapshot_time = DependenceRegistry.get_modify_time(source_path)
-        storage_dir = f"{ServerRegistry.HDFS.get('name_node')}/fate_dependence/{provider.version}"
-        os.system(f" {os.getenv('HADOOP_HOME')}/bin/hdfs dfs -mkdir -p  {storage_dir}")
-        status = os.system(f"{os.getenv('HADOOP_HOME')}/bin/hdfs dfs -put -f {target_file} {storage_dir}")
+        hdfs_address = ServerRegistry.FATE_ON_SPARK.get("hdfs", {}).get("name_node")
+        LOGGER.info(f'hdfs address: {hdfs_address}')
+        storage_dir = f"/fate_dependence/{provider.version}"
+        os.system(f" {os.getenv('HADOOP_HOME')}/bin/hdfs dfs -mkdir -p  {hdfs_address}{storage_dir}")
+        status = os.system(f"{os.getenv('HADOOP_HOME')}/bin/hdfs dfs -put -f {target_file} {hdfs_address}{storage_dir}")
         LOGGER.info(f'upload end, status is {status}')
         if status == 0:
             storage_path = os.path.join(storage_dir, os.path.basename(target_file))


### PR DESCRIPTION
## Pain point
The hdfs address will only work when flow, spark and hdfs share the same file system.

## Fix
Leverage the hdfs address in service_conf.yaml

## Test
Before change, the dependencies will not be uploaded to HDFS, but locally in the fateflow container.
After change, the dependencies can be uploaded to the real HDFS datanode