### PR TITLE
Update schedule_utils.py

### DIFF
--- a/python/fate_flow/utils/schedule_utils.py
+++ b/python/fate_flow/utils/schedule_utils.py
@@ -74,7 +74,7 @@ def schedule_lock(func):
             finally:
                 ready_signal(job_id=job.f_job_id, set_or_reset=False)
                 schedule_logger(job.f_job_id).info(f"release job {job.f_job_id} schedule lock")
-                return _result
+            return _result
         else:
             return func(*args, **kwargs)
     return _wrapper


### PR DESCRIPTION
If a return statement is included within the finally block, it will prematurely terminate the function, causing the Exception not to be caught.