### PR TITLE
fix: handle head:false table meta update bug

### DIFF
--- a/python/fate_flow/components/components/upload.py
+++ b/python/fate_flow/components/components/upload.py
@@ -233,7 +233,8 @@ class Upload:
             id_index = self.update_table_meta(data_head)
             read_status = True
         else:
-            pass
+            data_head = self.parameters.meta.header
+            id_index = self.update_table_meta(data_head)
         return id_index, read_status
 
     def upload_file(self, input_file, job_id, input_feature_count=None, table=None):


### PR DESCRIPTION
In order to solve issue #588 , read header line from config meta info in case of head: false, and correctly update table meta.